### PR TITLE
Claude/merge control api to main 5qr4k

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1323,6 +1323,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +1882,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1953,10 +1974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libm"
@@ -2518,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -3092,6 +3119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3613,8 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "http-body-util",
+ "hyper 0.14.32",
  "libp2p",
  "scmessenger-core",
  "serde",
@@ -4040,12 +4079,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4383,9 +4422,15 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
@@ -4685,6 +4730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,6 +4835,40 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"
@@ -4950,6 +5038,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5173,6 +5270,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5383,6 +5562,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,6 +37,8 @@ uuid = { workspace = true }
 warp = { version = "0.4.2", features = ["websocket", "server", "multipart"] }
 tokio-stream = "0.1.18"
 futures-util = "0.3.31"
+hyper = { version = "0.14", features = ["full"] }
+http-body-util = "0.1"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1,0 +1,304 @@
+// Control API for communicating with running SCMessenger node
+//
+// When `scm start` is running, it exposes a local HTTP API on localhost:9876
+// Other CLI commands can send requests to this API instead of accessing the database directly
+
+use anyhow::{Context, Result};
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+pub const API_PORT: u16 = 9876;
+pub const API_ADDR: &str = "127.0.0.1:9876";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendMessageRequest {
+    pub recipient: String,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendMessageResponse {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddContactRequest {
+    pub peer_id: String,
+    pub public_key: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddContactResponse {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetPeersResponse {
+    pub peers: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetHistoryRequest {
+    pub peer_id: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HistoryMessage {
+    pub peer_id: String,
+    pub content: String,
+    pub direction: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetHistoryResponse {
+    pub messages: Vec<HistoryMessage>,
+}
+
+// Check if API is available
+pub async fn is_api_available() -> bool {
+    match tokio::net::TcpStream::connect(API_ADDR).await {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+// Client functions for CLI commands
+
+pub async fn send_message_via_api(recipient: &str, message: &str) -> Result<()> {
+    let client = hyper::Client::new();
+    let req_body = SendMessageRequest {
+        recipient: recipient.to_string(),
+        message: message.to_string(),
+    };
+
+    let json = serde_json::to_string(&req_body)?;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("http://{}/api/send", API_ADDR))
+        .header("content-type", "application/json")
+        .body(Body::from(json))?;
+
+    let resp = client.request(req).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let response: SendMessageResponse = serde_json::from_slice(&body_bytes)?;
+
+    if response.success {
+        Ok(())
+    } else {
+        anyhow::bail!("Failed to send message: {}", response.error.unwrap_or_else(|| "Unknown error".to_string()))
+    }
+}
+
+pub async fn add_contact_via_api(peer_id: &str, public_key: &str, name: Option<String>) -> Result<()> {
+    let client = hyper::Client::new();
+    let req_body = AddContactRequest {
+        peer_id: peer_id.to_string(),
+        public_key: public_key.to_string(),
+        name,
+    };
+
+    let json = serde_json::to_string(&req_body)?;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("http://{}/api/contacts", API_ADDR))
+        .header("content-type", "application/json")
+        .body(Body::from(json))?;
+
+    let resp = client.request(req).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let response: AddContactResponse = serde_json::from_slice(&body_bytes)?;
+
+    if response.success {
+        Ok(())
+    } else {
+        anyhow::bail!("Failed to add contact: {}", response.error.unwrap_or_else(|| "Unknown error".to_string()))
+    }
+}
+
+pub async fn get_peers_via_api() -> Result<Vec<String>> {
+    let client = hyper::Client::new();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("http://{}/api/peers", API_ADDR))
+        .body(Body::empty())?;
+
+    let resp = client.request(req).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let response: GetPeersResponse = serde_json::from_slice(&body_bytes)?;
+
+    Ok(response.peers)
+}
+
+pub async fn get_history_via_api(peer_id: Option<String>, limit: Option<usize>) -> Result<Vec<HistoryMessage>> {
+    let client = hyper::Client::new();
+    let req_body = GetHistoryRequest { peer_id, limit };
+
+    let json = serde_json::to_string(&req_body)?;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("http://{}/api/history", API_ADDR))
+        .header("content-type", "application/json")
+        .body(Body::from(json))?;
+
+    let resp = client.request(req).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let response: GetHistoryResponse = serde_json::from_slice(&body_bytes)?;
+
+    Ok(response.messages)
+}
+
+// Server implementation
+
+pub struct ApiContext {
+    pub core: Arc<scmessenger_core::IronCore>,
+    pub contacts: Arc<crate::contacts::ContactList>,
+    pub history: Arc<crate::history::MessageHistory>,
+    pub swarm_handle: Arc<scmessenger_core::transport::SwarmHandle>,
+    pub peers: Arc<tokio::sync::Mutex<std::collections::HashMap<libp2p::PeerId, Option<String>>>>,
+}
+
+async fn handle_request(req: Request<Body>, ctx: Arc<ApiContext>) -> Result<Response<Body>, Infallible> {
+    let response = match (req.method(), req.uri().path()) {
+        (&Method::POST, "/api/send") => handle_send_message(req, ctx).await,
+        (&Method::POST, "/api/contacts") => handle_add_contact(req, ctx).await,
+        (&Method::GET, "/api/peers") => handle_get_peers(req, ctx).await,
+        (&Method::POST, "/api/history") => handle_get_history(req, ctx).await,
+        _ => Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from("Not found"))
+            .unwrap()),
+    };
+
+    Ok(response.unwrap_or_else(|e| {
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(format!("Error: {}", e)))
+            .unwrap()
+    }))
+}
+
+async fn handle_send_message(req: Request<Body>, ctx: Arc<ApiContext>) -> Result<Response<Body>> {
+    let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
+    let request: SendMessageRequest = serde_json::from_slice(&body_bytes)?;
+
+    // Find contact
+    let contact = crate::find_contact(&ctx.contacts, &request.recipient)?;
+
+    // Parse peer ID
+    let peer_id = contact.peer_id.parse::<libp2p::PeerId>()?;
+
+    // Prepare and send message
+    let envelope_bytes = ctx.core.prepare_message(contact.public_key.clone(), request.message.clone())?;
+    ctx.swarm_handle.send_message(peer_id, envelope_bytes).await?;
+
+    // Record in history
+    let record = crate::history::MessageRecord::new_sent(contact.peer_id.clone(), request.message);
+    ctx.history.add(record)?;
+
+    let response = SendMessageResponse {
+        success: true,
+        error: None,
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&response)?))?)
+}
+
+async fn handle_add_contact(req: Request<Body>, ctx: Arc<ApiContext>) -> Result<Response<Body>> {
+    let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
+    let request: AddContactRequest = serde_json::from_slice(&body_bytes)?;
+
+    let contact = crate::contacts::Contact::new(request.peer_id.clone(), request.public_key)
+        .with_nickname(request.name.unwrap_or_else(|| request.peer_id.clone()));
+
+    ctx.contacts.add(contact)?;
+
+    let response = AddContactResponse {
+        success: true,
+        error: None,
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&response)?))?)
+}
+
+async fn handle_get_peers(_req: Request<Body>, ctx: Arc<ApiContext>) -> Result<Response<Body>> {
+    let peers = ctx.peers.lock().await;
+    let peer_ids: Vec<String> = peers.keys().map(|p| p.to_string()).collect();
+
+    let response = GetPeersResponse {
+        peers: peer_ids,
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&response)?))?)
+}
+
+async fn handle_get_history(req: Request<Body>, ctx: Arc<ApiContext>) -> Result<Response<Body>> {
+    let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
+    let request: GetHistoryRequest = serde_json::from_slice(&body_bytes)?;
+
+    let messages = if let Some(peer_id) = request.peer_id {
+        ctx.history.conversation(&peer_id, request.limit.unwrap_or(20))?
+    } else {
+        ctx.history.recent(None, request.limit.unwrap_or(20))?
+    };
+
+    let history_messages: Vec<HistoryMessage> = messages.into_iter().map(|m| {
+        HistoryMessage {
+            peer_id: m.peer().to_string(),
+            content: m.content,
+            direction: match m.direction {
+                crate::history::Direction::Sent => "sent".to_string(),
+                crate::history::Direction::Received => "received".to_string(),
+            },
+            timestamp: m.timestamp,
+        }
+    }).collect();
+
+    let response = GetHistoryResponse {
+        messages: history_messages,
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&response)?))?)
+}
+
+pub async fn start_api_server(ctx: ApiContext) -> Result<()> {
+    let ctx = Arc::new(ctx);
+    let addr = SocketAddr::from(([127, 0, 0, 1], API_PORT));
+
+    let make_svc = make_service_fn(move |_conn| {
+        let ctx = ctx.clone();
+        async move {
+            Ok::<_, Infallible>(service_fn(move |req| {
+                handle_request(req, ctx.clone())
+            }))
+        }
+    });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    tracing::info!("Control API listening on {}", addr);
+
+    server.await.context("API server error")?;
+
+    Ok(())
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce a local HTTP Control API and update CLI commands to use it when a node is running. This removes sled DB locking issues and enables fully automated end-to-end testing.

- **New Features**
  - Control API starts with `scm start` on 127.0.0.1:9876.
  - Endpoints: /api/send, /api/contacts, /api/peers, /api/history.
  - `scm send` and `scm contact add` prefer the API; they fall back to offline/direct DB when no node is running.
  - `scm start` now spawns the API server and prints its URL.
  - Simulation script adds automated message delivery (Alice → Bob) via the API.

- **Dependencies**
  - Added hyper 0.14 and http-body-util 0.1.

<sup>Written for commit 048702151ccb150ad4b5e5216adf655bd883dfce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

