### PR TITLE
Fix unused variable warning and implement config UI commands

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -693,12 +693,21 @@ async fn cmd_start(port: Option<u16>) -> Result<()> {
                          }
                     }
                     server::UiCommand::ConfigGet { key } => {
-                        // Send simple value back? Or need a ConfigValue event?
-                        // For now, simpler to just List all on ConfigList
+                        if let Ok(cfg) = config::Config::load() {
+                            let value = cfg.get(&key);
+                            let _ = ui_broadcast.send(server::UiEvent::ConfigValue {
+                                key: key.clone(),
+                                value,
+                            });
+                        }
                     }
                     server::UiCommand::ConfigList => {
-                         // We might need a ConfigList event.
-                         // For MVP, maybe just log or ignore if no event type.
+                        if let Ok(cfg) = config::Config::load() {
+                            let config_data = cfg.list();
+                            let _ = ui_broadcast.send(server::UiEvent::ConfigData {
+                                config: config_data,
+                            });
+                        }
                     }
                     server::UiCommand::ConfigSet { key, value } => {
                         if let Ok(mut cfg) = config::Config::load() {

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -38,6 +38,13 @@ pub enum UiEvent {
         private_key: String,
         storage_path: String,
     },
+    ConfigValue {
+        key: String,
+        value: Option<String>,
+    },
+    ConfigData {
+        config: Vec<(String, String)>,
+    },
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Resolves unused variable warning for `key` in ConfigGet handler by fully implementing the ConfigGet and ConfigList UI command handlers.

Changes:
- Add ConfigValue and ConfigData UI events to server.rs
- Implement ConfigGet handler to retrieve and send config values to UI
- Implement ConfigList handler to send all config data to UI
- All variables are now properly used and functionality is complete

https://claude.ai/code/session_01RUxEpLY5faCiXDa3L8CEfU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented ConfigGet and ConfigList UI commands to send config values to the UI. Also fixed the unused variable warning in ConfigGet.

- New Features
  - Added UiEvent::ConfigValue { key, value } for single key lookups.
  - Added UiEvent::ConfigData { config } for returning the full config.
  - Handlers now load config and broadcast these events from main.rs.

<sup>Written for commit 1f33446bdad3830a8d3912387572ec082a7c9302. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

