### PR TITLE
Add Docker support and improve node deployment experience

### DIFF
--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -1,0 +1,265 @@
+# SCMessenger Docker Quick Start
+
+This guide gets you up and running with SCMessenger in Docker in under 5 minutes.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Ports 9000 and 9001 available (or configure different ports)
+
+## Single Node Setup
+
+The simplest way to run SCMessenger:
+
+```bash
+# 1. Build the image
+docker compose build
+
+# 2. Start the node
+docker compose up -d
+
+# 3. View logs
+docker compose logs -f
+
+# 4. Access the interactive CLI
+docker compose exec scmessenger bash -c "scm identity"
+```
+
+## GCP or Cloud Deployment
+
+### One-Command Deploy
+
+```bash
+# Build and run on a GCP VM or any cloud server
+docker build -t scmessenger -f docker/Dockerfile .
+
+# Run with persistent storage
+docker run -d \
+  --name scmessenger \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v ~/scm_data:/root/.local/share/scmessenger \
+  -v ~/scm_config:/root/.config/scmessenger \
+  -e LISTEN_PORT=9000 \
+  scmessenger
+
+# View your identity and Peer ID
+docker logs scmessenger
+```
+
+### With Bootstrap Nodes
+
+To connect your node to an existing network, add bootstrap nodes:
+
+```bash
+# Your GCP node's multiaddress format:
+# /ip4/<PUBLIC_IP>/tcp/9001/p2p/<PEER_ID>
+
+# Example with bootstrap node
+docker run -d \
+  --name scmessenger \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v ~/scm_data:/root/.local/share/scmessenger \
+  -e LISTEN_PORT=9000 \
+  -e BOOTSTRAP_NODES="/ip4/136.117.121.95/tcp/9001/p2p/12D3KooWGhWrfkwWRxmskC8bfGGvhd3gHYBQgigRbJeZL9Yd3W2S" \
+  scmessenger
+```
+
+## Connect Two Nodes (Local + Cloud)
+
+### Step 1: Start your cloud node (GCP)
+
+```bash
+# On your GCP VM
+docker run -d \
+  --name scmessenger \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v ~/scm_data:/root/.local/share/scmessenger \
+  scmessenger
+
+# Get the Peer ID from logs
+docker logs scmessenger | grep "Network peer ID"
+# Example output: ✓ Network peer ID: 12D3KooWGhWrfkwWRxmskC8bfGGvhd3gHYBQgigRbJeZL9Yd3W2S
+
+# Get your public IP
+curl ifconfig.me
+# Example output: 136.117.121.95
+```
+
+**Your cloud node's multiaddress:**
+```
+/ip4/<YOUR_PUBLIC_IP>/tcp/9001/p2p/<YOUR_PEER_ID>
+```
+
+### Step 2: Start your local node (Mac/Linux)
+
+```bash
+# On your local machine
+docker run -d \
+  --name scmessenger-local \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v ~/scm_data_local:/root/.local/share/scmessenger \
+  -e BOOTSTRAP_NODES="/ip4/136.117.121.95/tcp/9001/p2p/12D3KooWGhWrfkwWRxmskC8bfGGvhd3gHYBQgigRbJeZL9Yd3W2S" \
+  scmessenger
+
+# Check logs - you should see "Connected to bootstrap node"
+docker logs -f scmessenger-local
+```
+
+### Step 3: Verify Connection
+
+```bash
+# On local machine - check peer count
+docker exec scmessenger-local scm status
+
+# You should see "Peers: 1" or more
+```
+
+## Without Docker (Native Binary)
+
+If you prefer to run the binary directly:
+
+```bash
+# Build from source
+cargo build --release --bin scmessenger-cli
+
+# Start node
+./target/release/scmessenger-cli start --port 9000
+
+# Add bootstrap node
+./target/release/scmessenger-cli config bootstrap add \
+  /ip4/136.117.121.95/tcp/9001/p2p/12D3KooWGhWrfkwWRxmskC8bfGGvhd3gHYBQgigRbJeZL9Yd3W2S
+
+# Restart to connect
+./target/release/scmessenger-cli start --port 9000
+```
+
+## Port Configuration
+
+SCMessenger uses **two ports** by default:
+
+- **Port 9000**: WebSocket interface (for web UI and API)
+- **Port 9001**: P2P network communication (automatically set to `--port + 1`)
+
+When you specify `--port 9000`, the P2P port becomes 9001.
+
+**Both ports must be open in your firewall for internet connectivity.**
+
+### GCP Firewall Example
+
+```bash
+gcloud compute firewall-rules create allow-scmessenger \
+  --allow tcp:9000,udp:9000,tcp:9001,udp:9001 \
+  --description="SCMessenger P2P and WebSocket traffic" \
+  --direction=INGRESS
+```
+
+## Data Persistence
+
+Your identity and messages are stored in:
+- **Linux/Mac**: `~/.local/share/scmessenger/storage/`
+- **Docker**: Mounted volume (e.g., `~/scm_data/`)
+
+**Important**: The network keypair (which determines your Peer ID) is now persisted in:
+- `network_keypair.dat` - Your Peer ID will remain constant across restarts
+
+## Troubleshooting
+
+### Peer Count Stays at 0
+
+**Check 1**: Verify both nodes show "Listening on" messages:
+```bash
+docker logs scmessenger | grep "Listening on"
+```
+
+**Check 2**: Ensure firewall ports are open:
+```bash
+# Test from another machine
+nc -zv <YOUR_PUBLIC_IP> 9001
+```
+
+**Check 3**: Verify bootstrap address format:
+```
+/ip4/<IP>/tcp/9001/p2p/<PEER_ID>
+```
+All three components must be correct.
+
+**Check 4**: Check bootstrap connection logs:
+```bash
+docker logs scmessenger | grep -i bootstrap
+```
+
+### Identity Changes on Restart
+
+This should be fixed now! The network keypair is persisted. If you still see changing Peer IDs:
+- Ensure your volume mount is working (`-v ~/scm_data:/root/.local/share/scmessenger`)
+- Check that `network_keypair.dat` exists in the data directory
+
+### Port Already in Use
+
+```bash
+# Find what's using the port
+lsof -i :9000
+lsof -i :9001
+
+# Kill the process or change ports
+docker run -p 8000:9000 -p 8001:9001 -e LISTEN_PORT=9000 scmessenger
+```
+
+## Commands Reference
+
+### Docker
+
+```bash
+# Start node
+docker compose up -d
+
+# Stop node
+docker compose down
+
+# View logs
+docker compose logs -f
+
+# Restart node
+docker compose restart
+
+# Remove everything (including data)
+docker compose down -v
+```
+
+### CLI (inside container)
+
+```bash
+# Show identity
+docker exec scmessenger scm identity
+
+# Add contact
+docker exec scmessenger scm contact add <peer_id> <public_key> --name "Alice"
+
+# List contacts
+docker exec scmessenger scm contact list
+
+# Check status
+docker exec scmessenger scm status
+
+# View history
+docker exec scmessenger scm history
+
+# Bootstrap nodes management
+docker exec scmessenger scm config bootstrap list
+docker exec scmessenger scm config bootstrap add <multiaddr>
+```
+
+## Next Steps
+
+1. Open the web UI: `http://localhost:9000` (UI implementation in progress)
+2. Add contacts via CLI
+3. Send messages!
+
+## Support
+
+- Report issues: https://github.com/Treystu/SCMessenger/issues
+- See main README.md for architecture details

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -49,9 +49,12 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             bootstrap_nodes: vec![
-                // Empty by default - users add their own
+                // Default public relay for bootstrapping
+                // Users can add their own via `scm config bootstrap add <addr>`
+                // Note: These will be populated once we deploy public relay nodes
+                // For now, users manually add their first bootstrap node
             ],
-            listen_port: 0, // Random port
+            listen_port: 9000, // Default to 9000 instead of random
             enable_mdns: true,
             enable_dht: true,
             storage_path: None,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  # Single SCMessenger node - simplest deployment
+  scmessenger:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: scmessenger-node
+    ports:
+      - "9000:9000"  # WebSocket UI port
+      - "9001:9001"  # P2P network port
+    environment:
+      - RUST_LOG=info
+      - LISTEN_PORT=9000
+      # Add bootstrap nodes as comma-separated multiaddrs
+      # Example: BOOTSTRAP_NODES=/ip4/136.117.121.95/tcp/9001/p2p/12D3KooW...
+      - BOOTSTRAP_NODES=${BOOTSTRAP_NODES:-}
+    volumes:
+      - scm-data:/root/.local/share/scmessenger
+      - scm-config:/root/.config/scmessenger
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+volumes:
+  scm-data:
+    driver: local
+  scm-config:
+    driver: local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Install runtime dependencies and network tools for simulation
+# Install runtime dependencies and network tools
 RUN apt-get update && apt-get install -y \
     openssl \
     ca-certificates \
@@ -48,7 +48,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Environment variables
 ENV RUST_LOG=info
 ENV SCM_CONFIG_DIR=/root/.config/scmessenger
-ENV PORT=8080
+ENV SCM_DATA_DIR=/root/.local/share/scmessenger
+ENV LISTEN_PORT=9000
+
+# Expose ports
+EXPOSE 9000 9001
 
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["sh", "-c", "scm start --port $PORT"]
+CMD ["scm", "start"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,53 +1,21 @@
 #!/bin/bash
 set -e
 
-# Initialize config directory
+# Initialize config and data directories
 mkdir -p "$SCM_CONFIG_DIR"
+mkdir -p "$SCM_DATA_DIR"
 CONFIG_FILE="$SCM_CONFIG_DIR/config.json"
 
-# Create default config if it doesn't exist
-if [ ! -f "$CONFIG_FILE" ]; then
+# Determine the port to use (priority: LISTEN_PORT > PORT > default 9000)
+FINAL_PORT="${LISTEN_PORT:-${PORT:-9000}}"
+
+# Create or update config if needed
+if [ ! -f "$CONFIG_FILE" ] || [ ! -s "$CONFIG_FILE" ] || [ "$(cat "$CONFIG_FILE")" = "{}" ]; then
     echo "Creating default configuration..."
-    echo '{}' > "$CONFIG_FILE"
-fi
-
-# Function to update nested JSON fields using temporary files and grep/sed/awk
-# Note: In a real production environment, jq is preferred, but we want to minimize dependencies
-# or we can install jq in the Dockerfile. For simplicity, we'll use a basic approach
-# or just rely on 'scm config set' if the CLI supports it.
-
-# Let's use the CLI itself to configure, which is robust
-# Wait, 'scm config set' might expect 'scm init' to have run.
-# 'scm init' is interactive. We need a way to init non-interactively or just start with defaults.
-# The 'scm start' command handles initialization if identity is missing.
-
-# Set listen port if provided
-# Set listen port from Cloud Run's $PORT or custom $LISTEN_PORT
-PORT="${PORT:-${LISTEN_PORT}}"
-
-if [ ! -z "$PORT" ]; then
-    echo "Setting listen port to $PORT"
-    # We can use sed to patch config.json since it's simple JSON
-    # Or better, run scm commands if they support non-interactive setup
-fi
-
-# Actually, the CLI's `config::Config::load()` creates a default config if missing.
-# We can manipulate the file directly or via CLI commands IF we modify the CLI to support non-interactive init.
-# For now, let's inject a basic valid config.json using jq (we should add jq to Dockerfile for ease)
-
-# Check if jq is installed, if not, warn or fail
-if ! command -v jq &> /dev/null; then
-    echo "jq is not installed. Installing..."
-    apt-get update && apt-get install -y jq
-fi
-
-# Base config structure
-if [ ! -s "$CONFIG_FILE" ] || [ "$(cat "$CONFIG_FILE")" = "{}" ]; then
-    # Create valid initial config
     cat > "$CONFIG_FILE" <<EOF
 {
   "bootstrap_nodes": [],
-  "listen_port": ${PORT:-0},
+  "listen_port": ${FINAL_PORT},
   "enable_mdns": true,
   "enable_dht": true,
   "storage_path": null,
@@ -59,29 +27,31 @@ if [ ! -s "$CONFIG_FILE" ] || [ "$(cat "$CONFIG_FILE")" = "{}" ]; then
   }
 }
 EOF
+else
+    # Update existing config with environment variables
+    tmp=$(mktemp)
+    jq --arg port "$FINAL_PORT" '.listen_port = ($port | tonumber)' "$CONFIG_FILE" > "$tmp" && mv "$tmp" "$CONFIG_FILE"
 fi
 
 # Add bootstrap nodes from environment variable (comma separated)
 if [ ! -z "$BOOTSTRAP_NODES" ]; then
     echo "Configuring bootstrap nodes..."
-    # Split by comma and add each
     IFS=',' read -ra ADDR <<< "$BOOTSTRAP_NODES"
     for i in "${ADDR[@]}"; do
-        # Use jq to add to array if not present
         tmp=$(mktemp)
         jq --arg node "$i" '.bootstrap_nodes += [$node] | .bootstrap_nodes |= unique' "$CONFIG_FILE" > "$tmp" && mv "$tmp" "$CONFIG_FILE"
     done
 fi
 
-# Update listen port if specified
-# Update listen port if specified
-if [ ! -z "$PORT" ]; then
-    tmp=$(mktemp)
-    jq --arg port "$PORT" '.listen_port = ($port | tonumber)' "$CONFIG_FILE" > "$tmp" && mv "$tmp" "$CONFIG_FILE"
+echo "✓ Configuration ready (port: $FINAL_PORT)"
+
+# If no port argument is provided to scm start, add it
+if [ "$1" = "scm" ] && [ "$2" = "start" ]; then
+    # Check if --port is already in arguments
+    if ! echo "$@" | grep -q "\-\-port"; then
+        set -- "$1" "$2" "--port" "$FINAL_PORT" "${@:3}"
+    fi
 fi
 
-echo "Configuration complete:"
-cat "$CONFIG_FILE"
-
-# Run the command passed to arguments
+# Run the command
 exec "$@"


### PR DESCRIPTION
## Summary
This PR adds comprehensive Docker support to SCMessenger and improves the overall deployment experience with persistent network identities, better port configuration, and bootstrap node connectivity.

## Key Changes

### Docker & Deployment
- **Added `docker-compose.yml`**: Simple single-node setup with volume persistence for data and config
- **Updated `docker/Dockerfile`**: 
  - Simplified entrypoint and environment variables
  - Changed default port from 8080 to 9000
  - Added EXPOSE directives for ports 9000 (WebSocket) and 9001 (P2P)
  - Removed unnecessary simulation-specific comments
- **Rewrote `docker/entrypoint.sh`**: 
  - Cleaner configuration initialization using jq
  - Support for `LISTEN_PORT` and `BOOTSTRAP_NODES` environment variables
  - Automatic port injection into CLI commands
  - Creates both config and data directories

### Network & Identity Persistence
- **Persistent Network Keypair** (`cli/src/main.rs`):
  - Network keypair now saved to `network_keypair.dat` in data directory
  - Peer ID remains constant across container restarts
  - Automatic generation and persistence on first run
- **Bootstrap Node Connectivity** (`cli/src/main.rs`):
  - Added automatic dialing of configured bootstrap nodes on startup
  - Implements 3-attempt retry logic with 5-second intervals
  - Provides user-friendly connection status messages

### Configuration Improvements
- **Default Port** (`cli/src/config.rs`):
  - Changed default listen port from 0 (random) to 9000
  - More predictable and user-friendly for Docker deployments
  - Maintains backward compatibility with explicit port arguments

### Documentation
- **Added `DOCKER_QUICKSTART.md`**: Comprehensive guide covering:
  - Single-node local setup with docker-compose
  - GCP/cloud deployment with persistent storage
  - Multi-node networking (local + cloud)
  - Native binary alternative
  - Port configuration and firewall setup
  - Troubleshooting guide with common issues
  - CLI commands reference

## Implementation Details

The persistent keypair implementation uses libp2p's protobuf encoding to serialize/deserialize the Ed25519 keypair, ensuring the same Peer ID across restarts. Bootstrap node connectivity is handled asynchronously with proper error handling and logging.

The Docker setup supports both simple local development (via docker-compose) and production cloud deployments (via direct docker run commands) with environment variable configuration for maximum flexibility.

https://claude.ai/code/session_01VbRBdCmy9D45msXcXgPmyu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Docker support and stable network identity to SCMessenger for predictable, one-command deployments. Also enables automatic bootstrap dialing and standardizes ports (9000/9001), addressing previous startup and connectivity issues.

- **New Features**
  - Dockerized deployment: docker-compose, simplified Dockerfile/entrypoint, EXPOSE 9000/9001, LISTEN_PORT and BOOTSTRAP_NODES envs, persistent volumes, and a Quickstart guide.
  - Persistent identity: libp2p keypair saved to network_keypair.dat so the Peer ID stays the same across restarts.
  - Bootstrap connectivity: auto-dials configured nodes on startup with 3 attempts and clear logs.
  - Predictable ports: default listen_port 9000; P2P on 9001; CLI falls back to 9000 when config was 0.

<sup>Written for commit 86cf1cdf16540da7564858ac95ec2a8458f363d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

