### PR TITLE
Fix missing Multiaddr import in CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ mod server;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use colored::*;
+use libp2p::Multiaddr;
 use scmessenger_core::transport::{self, SwarmEvent};
 use scmessenger_core::IronCore;
 use std::collections::HashMap;


### PR DESCRIPTION
- Add libp2p::Multiaddr import for bootstrap node dialing
- Fixes compilation error in docker build

https://claude.ai/code/session_01VbRBdCmy9D45msXcXgPmyu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing libp2p::Multiaddr import in the CLI to fix Docker build compilation errors and enable bootstrap node dialing.

<sup>Written for commit 973ae5143cf0f6be3fbc294e479233653992ca2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

