### PR TITLE
Wiring: Baseline Compilation Fixes — Phase 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5249,6 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -74,33 +74,33 @@ For lifecycle classification (`Active`, `Planned`, `Mixed`, `Historical`, `Super
 
 Custom modes, rules, and skills for optimized agent workflows:
 
-**Custom Modes** (`.roomodes/`):
-- [`scm-rust`](.roomodes/scm-rust.json) - Rust core development
-- [`scm-android`](.roomodes/scm-android.json) - Android/Kotlin development
-- [`scm-ios`](.roomodes/scm-ios.json) - iOS/Swift development
-- [`scm-protocol`](.roomodes/scm-protocol.json) - Protocol/crypto review
-- [`scm-docs`](.roomodes/scm-docs.json) - Documentation specialist
-- [`scm-release`](.roomodes/scm-release.json) - Release verification
-- [`scm-debug-mesh`](.roomodes/scm-debug-mesh.json) - Mesh/relay debugging
+**Custom Modes** (`.roomodes/`): historical references only; the `.roomodes/` directory is not tracked in this repository snapshot.
+- `scm-rust` - Rust core development
+- `scm-android` - Android/Kotlin development
+- `scm-ios` - iOS/Swift development
+- `scm-protocol` - Protocol/crypto review
+- `scm-docs` - Documentation specialist
+- `scm-release` - Release verification
+- `scm-debug-mesh` - Mesh/relay debugging
 
-**Project Rules** (`.roo/rules/`):
-- [`000-critical.md`](.roo/rules/000-critical.md) - Non-negotiable rules
-- [`010-documentation.md`](.roo/rules/010-documentation.md) - Doc sync requirements
-- [`020-crypto.md`](.roo/rules/020-crypto.md) - Cryptography constraints
-- [`030-platform-parity.md`](.roo/rules/030-platform-parity.md) - Cross-platform rules
-- [`040-build-verify.md`](.roo/rules/040-build-verify.md) - Build verification
-- [`050-identity.md`](.roo/rules/050-identity.md) - Identity model rules
-- [`060-testing.md`](.roo/rules/060-testing.md) - Test requirements
+**Project Rules** (`.roo/rules/`): historical references only; the `.roo/rules/` directory is not tracked in this repository snapshot.
+- `000-critical.md` - Non-negotiable rules
+- `010-documentation.md` - Doc sync requirements
+- `020-crypto.md` - Cryptography constraints
+- `030-platform-parity.md` - Cross-platform rules
+- `040-build-verify.md` - Build verification
+- `050-identity.md` - Identity model rules
+- `060-testing.md` - Test requirements
 
 **Skills** (`skills/`):
 - [`platform-parity-check`](skills/platform-parity-check/SKILL.md) - Cross-platform verification
 - [`release-gate-validator`](skills/release-gate-validator/SKILL.md) - Release readiness
 - [`mesh-diagnostics`](skills/mesh-diagnostics/SKILL.md) - Network troubleshooting
 
-**Memory Bank** (`.roo/memory-bank/`):
-- [`projectbrief.md`](.roo/memory-bank/projectbrief.md) - Project overview
-- [`techContext.md`](.roo/memory-bank/techContext.md) - Technology stack
-- [`activeContext.md`](.roo/memory-bank/activeContext.md) - Current focus
+**Memory Bank** (`.roo/memory-bank/`): historical references only; the `.roo/memory-bank/` directory is not tracked in this repository snapshot.
+- `projectbrief.md` - Project overview
+- `techContext.md` - Technology stack
+- `activeContext.md` - Current focus
 
 ## Component and Platform Docs
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,6 +66,7 @@ libp2p = { workspace = true, features = [
 ] }
 quinn = "0.11"
 ureq = "2"
+libc = "0.2"
 tokio-tungstenite = { workspace = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), target_os = "android"))'.dependencies]
@@ -108,7 +109,7 @@ rand = { workspace = true }
 uniffi = { workspace = true, features = ["build"] }
 
 [features]
-default = []
+default = ["phase2_apis"]
 gen-bindings = ["dep:uniffi_bindgen", "dep:camino"]
 wasm = ["uniffi/wasm-unstable-single-threaded"]
 kani-proofs = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ camino = { version = "1", optional = true }
 
 # Additional dependencies
 parking_lot = "0.12"
-web-time = "1.1"
+web-time = { version = "1.1", features = ["serde"] }
 crc32fast = "1.3"
 lz4_flex = { version = "0.11", default-features = false, features = ["std"] }
 pbkdf2 = { version = "0.12.2", features = ["sha2"] }

--- a/core/src/api.udl
+++ b/core/src/api.udl
@@ -338,7 +338,6 @@ dictionary ServiceStats {
 };
 
 interface MeshService {
-    [Self=ByArc]
     constructor(MeshServiceConfig config);
     [Name=with_storage]
     constructor(MeshServiceConfig config, string storage_path);

--- a/core/src/api.udl
+++ b/core/src/api.udl
@@ -396,6 +396,8 @@ callback interface PlatformBridge {
 // ============================================================================
 
 dictionary DeviceProfile {
+    string? peer_id;
+    string? device_id;
     u8 battery_pct;
     boolean is_charging;
     boolean has_wifi;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,7 +32,7 @@ pub mod contacts_bridge;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mobile_bridge;
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
@@ -331,6 +331,9 @@ pub struct IronCore {
     /// Engine for computing adaptive mesh behavior (P1_CORE_ENTRY_001)
     #[cfg(not(target_arch = "wasm32"))]
     pub auto_adjust_engine: Arc<mobile_bridge::AutoAdjustEngine>,
+    /// Running swarm handle for transport queries exposed through IronCore.
+    #[cfg(not(target_arch = "wasm32"))]
+    swarm_handle: Arc<Mutex<Option<crate::transport::swarm::SwarmHandle>>>,
 }
 
 const STORAGE_SCHEMA_VERSION: u32 = 3;
@@ -859,6 +862,8 @@ impl IronCore {
             routing_engine,
             #[cfg(not(target_arch = "wasm32"))]
             auto_adjust_engine: Arc::new(mobile_bridge::AutoAdjustEngine::new()),
+            #[cfg(not(target_arch = "wasm32"))]
+            swarm_handle: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -2909,8 +2914,9 @@ impl IronCore {
         // However, some nodes might have their own local custody store if they are relays.
         // We can create a temporary one to check the storage if it's persistent.
         if let Some(peer_id) = self.libp2p_peer_id() {
-             let store = store::relay_custody::RelayCustodyStore::for_local_peer(&peer_id);
-             store.audit_count() as u32
+            let local_peer_id = peer_id.to_string();
+            let store = store::relay_custody::RelayCustodyStore::for_local_peer(&local_peer_id);
+            store.audit_count() as u32
         } else {
             0
         }
@@ -2919,13 +2925,14 @@ impl IronCore {
     /// Get registration state info for an identity ID (Blake3 hash).
     pub fn custody_get_registration_state_info(&self, identity_id: String) -> RegistrationStateInfo {
         if let Some(peer_id) = self.libp2p_peer_id() {
-             let store = store::relay_custody::RelayCustodyStore::for_local_peer(&peer_id);
-             let info = store.get_registration_state_info(&identity_id);
-             RegistrationStateInfo {
-                 state: info.state,
-                 device_id: info.device_id,
-                 seniority_timestamp: info.seniority_timestamp,
-             }
+            let local_peer_id = peer_id.to_string();
+            let store = store::relay_custody::RelayCustodyStore::for_local_peer(&local_peer_id);
+            let info = store.get_registration_state_info(&identity_id);
+            RegistrationStateInfo {
+                state: info.state,
+                device_id: info.device_id,
+                seniority_timestamp: info.seniority_timestamp,
+            }
         } else {
             RegistrationStateInfo {
                 state: "unknown".to_string(),
@@ -2938,9 +2945,10 @@ impl IronCore {
     /// Get registration transitions for an identity as JSON.
     pub fn custody_registration_transitions(&self, identity_id: String) -> String {
         if let Some(peer_id) = self.libp2p_peer_id() {
-             let store = store::relay_custody::RelayCustodyStore::for_local_peer(&peer_id);
-             let transitions = store.registration_transitions_for_identity(&identity_id);
-             serde_json::to_string(&transitions).unwrap_or_else(|_| "[]".to_string())
+            let local_peer_id = peer_id.to_string();
+            let store = store::relay_custody::RelayCustodyStore::for_local_peer(&local_peer_id);
+            let transitions = store.registration_transitions_for_identity(&identity_id);
+            serde_json::to_string(&transitions).unwrap_or_else(|_| "[]".to_string())
         } else {
             "[]".to_string()
         }
@@ -2991,7 +2999,7 @@ impl IronCore {
             Some(h) => h,
             None => return vec![],
         };
-        let target = match target_peer_id.parse::<PeerId>() {
+        let target = match target_peer_id.parse::<libp2p::PeerId>() {
             Ok(p) => p,
             Err(_) => return vec![],
         };
@@ -3025,25 +3033,20 @@ impl IronCore {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn libp2p_peer_id(&self) -> Option<libp2p::PeerId> {
         let id = self.identity.read();
-        let pub_key_bytes = id.public_key_bytes()?;
-        if pub_key_bytes.len() < 32 {
-            return None;
-        }
-        let mut key_arr = [0u8; 32];
-        key_arr.copy_from_slice(&pub_key_bytes[..32]);
-        let ed_pk = libp2p::identity::ed25519::PublicKey::try_from_bytes(&key_arr).ok()?;
-        Some(libp2p::PeerId::from_public_key(
-            &libp2p::identity::PublicKey::from(ed_pk),
-        ))
+        let keypair = id.keys()?.to_libp2p_keypair().ok()?;
+        Some(libp2p::PeerId::from_public_key(&keypair.public()))
     }
 
     /// Return the swarm handle for transport operations, if the swarm is running.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn get_swarm_handle(&self) -> Option<crate::transport::swarm::SwarmHandle> {
-        // SwarmHandle is stored externally by MeshService's SwarmBridge.
-        // IronCore does not own it directly — callers should use the SwarmBridge.
-        // This stub returns None; mobile_bridge wires the real path.
-        None
+        self.swarm_handle.lock().clone()
+    }
+
+    /// Store the running swarm handle so query helpers can return live data.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn set_swarm_handle(&self, handle: crate::transport::swarm::SwarmHandle) {
+        *self.swarm_handle.lock() = Some(handle);
     }
 
     /// Re-initialize the routing engine with the real identity after initialization.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -235,6 +235,13 @@ pub struct RegistrationStateInfo {
     pub seniority_timestamp: Option<u64>,
 }
 
+/// Result of peeling one onion layer — next hop address and remaining payload.
+#[derive(Clone)]
+pub struct PeelResult {
+    pub next_hop: Option<Vec<u8>>,
+    pub remaining_data: Vec<u8>,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 struct IdentityBackupV1 {
     version: u8,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3017,6 +3017,9 @@ impl IronCore {
 
     /// Return a random available port number. Used by the transport layer to find
     /// a free port for listening when no explicit port is configured.
+    ///
+    /// Returns `0` if no free port can be found (OS refused the ephemeral bind).
+    /// Callers must treat `0` as a failure sentinel and not attempt to bind to it.
     pub fn random_port(&self) -> u16 {
         use std::net::TcpListener;
         TcpListener::bind("127.0.0.1:0")

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3033,8 +3033,12 @@ impl IronCore {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn libp2p_peer_id(&self) -> Option<libp2p::PeerId> {
         let id = self.identity.read();
-        let keypair = id.keys()?.to_libp2p_keypair().ok()?;
-        Some(libp2p::PeerId::from_public_key(&keypair.public()))
+        let public_key_bytes = id.keys()?.signing_key.verifying_key().to_bytes();
+        let public_key =
+            libp2p::identity::ed25519::PublicKey::try_from_bytes(&public_key_bytes).ok()?;
+        Some(libp2p::PeerId::from_public_key(
+            &libp2p::identity::PublicKey::from(public_key),
+        ))
     }
 
     /// Return the swarm handle for transport operations, if the swarm is running.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -855,6 +855,10 @@ impl IronCore {
             ratchet_session_manager,
             #[cfg(not(target_arch = "wasm32"))]
             ledger_manager,
+            abuse_reputation,
+            routing_engine,
+            #[cfg(not(target_arch = "wasm32"))]
+            auto_adjust_engine: Arc::new(mobile_bridge::AutoAdjustEngine::new()),
         }
     }
 
@@ -3001,6 +3005,45 @@ impl IronCore {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn get_auto_adjust_engine(&self) -> Arc<crate::mobile_bridge::AutoAdjustEngine> {
         self.auto_adjust_engine.clone()
+    }
+
+    // ========================================================================
+    // IDENTITY ACCESSORS (wired for mobile_bridge + custody callers)
+    // ========================================================================
+
+    /// Return the current identity_id (Blake3 hash of public key), if initialized.
+    pub fn identity_id(&self) -> Option<String> {
+        self.identity.read().identity_id()
+    }
+
+    /// Return the current device_id (UUID v4), if initialized.
+    pub fn device_id(&self) -> Option<String> {
+        self.identity.read().device_id()
+    }
+
+    /// Return the libp2p PeerId derived from the current identity key, if initialized.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn libp2p_peer_id(&self) -> Option<libp2p::PeerId> {
+        let id = self.identity.read();
+        let pub_key_bytes = id.public_key_bytes()?;
+        if pub_key_bytes.len() < 32 {
+            return None;
+        }
+        let mut key_arr = [0u8; 32];
+        key_arr.copy_from_slice(&pub_key_bytes[..32]);
+        let ed_pk = libp2p::identity::ed25519::PublicKey::try_from_bytes(&key_arr).ok()?;
+        Some(libp2p::PeerId::from_public_key(
+            &libp2p::identity::PublicKey::from(ed_pk),
+        ))
+    }
+
+    /// Return the swarm handle for transport operations, if the swarm is running.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn get_swarm_handle(&self) -> Option<crate::transport::swarm::SwarmHandle> {
+        // SwarmHandle is stored externally by MeshService's SwarmBridge.
+        // IronCore does not own it directly — callers should use the SwarmBridge.
+        // This stub returns None; mobile_bridge wires the real path.
+        None
     }
 
     /// Re-initialize the routing engine with the real identity after initialization.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3015,6 +3015,17 @@ impl IronCore {
         self.auto_adjust_engine.clone()
     }
 
+    /// Return a random available port number. Used by the transport layer to find
+    /// a free port for listening when no explicit port is configured.
+    pub fn random_port(&self) -> u16 {
+        use std::net::TcpListener;
+        TcpListener::bind("127.0.0.1:0")
+            .ok()
+            .and_then(|l| l.local_addr().ok())
+            .map(|a| a.port())
+            .unwrap_or(0)
+    }
+
     // ========================================================================
     // IDENTITY ACCESSORS (wired for mobile_bridge + custody callers)
     // ========================================================================

--- a/core/src/mobile_bridge.rs
+++ b/core/src/mobile_bridge.rs
@@ -134,7 +134,7 @@ pub struct ServiceStats {
 pub struct MeshService {
     _config: Mutex<MeshServiceConfig>,
     state: Mutex<ServiceState>,
-    stats: Mutex<ServiceStats>,
+    stats: Arc<Mutex<ServiceStats>>,
     pub(crate) nearby_ble_peers: Arc<Mutex<HashSet<String>>>,
     core: std::sync::Arc<Mutex<Option<std::sync::Arc<crate::IronCore>>>>,
     platform_bridge: std::sync::Arc<Mutex<Option<Box<dyn PlatformBridge>>>>,
@@ -157,44 +157,48 @@ pub struct MeshService {
 
 impl MeshService {
     pub fn new(config: MeshServiceConfig) -> Self {
+        let swarm_bridge = std::sync::Arc::new(SwarmBridge::new());
+        let nearby_ble_peers = swarm_bridge.nearby_ble_peers.clone();
         Self {
             _config: Mutex::new(config),
             state: Mutex::new(ServiceState::Stopped),
-            stats: Mutex::new(ServiceStats::default()),
+            stats: Arc::new(Mutex::new(ServiceStats::default())),
             core: std::sync::Arc::new(Mutex::new(None)),
             platform_bridge: std::sync::Arc::new(Mutex::new(None)),
             storage_path: None,
             log_directory: None,
-            swarm_bridge: std::sync::Arc::new(SwarmBridge::new()),
+            swarm_bridge,
             nat_status: std::sync::Arc::new(Mutex::new("unknown".to_string())),
             relay_budget: std::sync::Arc::new(Mutex::new(200)),
             swarm_headless_mode: std::sync::Arc::new(Mutex::new(None)),
             current_device_profile: Mutex::new(None),
             device_state: RwLock::new(None),
             auto_adjust: Arc::new(AutoAdjustEngine::new()),
-            nearby_ble_peers: Arc::new(Mutex::new(HashSet::new())),
+            nearby_ble_peers,
             external_delegate: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Create MeshService with persistent storage
     pub fn with_storage(config: MeshServiceConfig, storage_path: String) -> Self {
+        let swarm_bridge = std::sync::Arc::new(SwarmBridge::new());
+        let nearby_ble_peers = swarm_bridge.nearby_ble_peers.clone();
         Self {
             _config: Mutex::new(config),
             state: Mutex::new(ServiceState::Stopped),
-            stats: Mutex::new(ServiceStats::default()),
+            stats: Arc::new(Mutex::new(ServiceStats::default())),
             core: std::sync::Arc::new(Mutex::new(None)),
             platform_bridge: std::sync::Arc::new(Mutex::new(None)),
             storage_path: Some(storage_path),
             log_directory: None,
-            swarm_bridge: std::sync::Arc::new(SwarmBridge::new()),
+            swarm_bridge,
             nat_status: std::sync::Arc::new(Mutex::new("unknown".to_string())),
             relay_budget: std::sync::Arc::new(Mutex::new(200)),
             swarm_headless_mode: std::sync::Arc::new(Mutex::new(None)),
             current_device_profile: Mutex::new(None),
             device_state: RwLock::new(None),
             auto_adjust: Arc::new(AutoAdjustEngine::new()),
-            nearby_ble_peers: Arc::new(Mutex::new(HashSet::new())),
+            nearby_ble_peers,
             external_delegate: Arc::new(Mutex::new(None)),
         }
     }
@@ -205,22 +209,24 @@ impl MeshService {
         storage_path: String,
         log_directory: String,
     ) -> Self {
+        let swarm_bridge = std::sync::Arc::new(SwarmBridge::new());
+        let nearby_ble_peers = swarm_bridge.nearby_ble_peers.clone();
         Self {
             _config: Mutex::new(config),
             state: Mutex::new(ServiceState::Stopped),
-            stats: Mutex::new(ServiceStats::default()),
+            stats: Arc::new(Mutex::new(ServiceStats::default())),
             core: std::sync::Arc::new(Mutex::new(None)),
             platform_bridge: std::sync::Arc::new(Mutex::new(None)),
             storage_path: Some(storage_path),
             log_directory: Some(log_directory),
-            swarm_bridge: std::sync::Arc::new(SwarmBridge::new()),
+            swarm_bridge,
             nat_status: std::sync::Arc::new(Mutex::new("unknown".to_string())),
             relay_budget: std::sync::Arc::new(Mutex::new(200)),
             swarm_headless_mode: std::sync::Arc::new(Mutex::new(None)),
             current_device_profile: Mutex::new(None),
             device_state: RwLock::new(None),
             auto_adjust: Arc::new(AutoAdjustEngine::new()),
-            nearby_ble_peers: Arc::new(Mutex::new(HashSet::new())),
+            nearby_ble_peers,
             external_delegate: Arc::new(Mutex::new(None)),
         }
     }
@@ -578,8 +584,8 @@ impl MeshService {
                                 None,
                                 Vec::new(),
                                 service_storage_path,
-                                iron_core_handle.map(|c| {
-                                    Arc::downgrade(&c)
+                                iron_core_handle.as_ref().map(|c| {
+                                    Arc::downgrade(c)
                                 }),
                                 headless_mode,
                             )
@@ -2086,6 +2092,7 @@ impl LedgerManager {
 pub struct SwarmBridge {
     handle: Arc<Mutex<Option<SwarmHandle>>>,
     captured_handle: Option<tokio::runtime::Handle>,
+    pub nearby_ble_peers: Arc<Mutex<HashSet<String>>>,
 }
 
 impl Default for SwarmBridge {
@@ -2132,6 +2139,7 @@ impl SwarmBridge {
         Self {
             handle: Arc::new(Mutex::new(None)),
             captured_handle: Some(get_global_runtime()),
+            nearby_ble_peers: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -2146,6 +2154,13 @@ impl SwarmBridge {
         self.captured_handle
             .clone()
             .unwrap_or_else(get_global_runtime)
+    }
+
+    /// Dispatch a packet to a BLE-reachable peer.
+    /// SwarmBridge does not own a platform bridge, so this is a no-op stub; the
+    /// real dispatch path is through MeshService::dispatch_ble_packet.
+    pub fn dispatch_ble_packet(&self, _peer_id: String, _data: Vec<u8>) {
+        tracing::debug!("SwarmBridge::dispatch_ble_packet: BLE dispatch not wired through SwarmBridge");
     }
 
     /// Send an encrypted message envelope to a peer.

--- a/core/src/mobile_bridge.rs
+++ b/core/src/mobile_bridge.rs
@@ -2160,7 +2160,7 @@ impl SwarmBridge {
     /// SwarmBridge does not own a platform bridge, so this is a no-op stub; the
     /// real dispatch path is through MeshService::dispatch_ble_packet.
     pub fn dispatch_ble_packet(&self, _peer_id: String, _data: Vec<u8>) {
-        tracing::debug!("SwarmBridge::dispatch_ble_packet: BLE dispatch not wired through SwarmBridge");
+        tracing::warn!("SwarmBridge::dispatch_ble_packet: BLE dispatch not wired through SwarmBridge; packet dropped");
     }
 
     /// Send an encrypted message envelope to a peer.

--- a/core/src/mobile_bridge.rs
+++ b/core/src/mobile_bridge.rs
@@ -614,7 +614,7 @@ impl MeshService {
                                                                 
                                                                 eprintln!("[IronCore] 🧅 Onion relay: forwarding to {}", next_hop_hex);
                                                                 if let Ok(next_hop_bytes) = hex::decode(&next_hop_hex) {
-                                                                    if let Ok(libp2p_pk) = libp2p::identity::ed25519::PublicKey::try_from(&next_hop_bytes[..32]) {
+                                                                    if let Ok(libp2p_pk) = libp2p::identity::ed25519::PublicKey::try_from_bytes(&next_hop_bytes[..32]) {
                                                                         let next_peer_id = libp2p::PeerId::from_public_key(&libp2p::identity::PublicKey::from(libp2p_pk));
                                                                         
                                                                         let bridge_clone = swarm_bridge.clone();
@@ -1185,7 +1185,7 @@ struct MeshServiceCoreDelegate {
 impl crate::CoreDelegate for MeshServiceCoreDelegate {
     fn on_peer_discovered(&self, peer_id: String) {
         if let Some(service) = self.service.upgrade() {
-            service.on_peer_discovered(peer_id);
+            service.on_peer_discovered(peer_id.clone());
             if let Some(delegate) = service.external_delegate.lock().as_ref() {
                 delegate.on_peer_discovered(peer_id);
             }
@@ -1194,7 +1194,7 @@ impl crate::CoreDelegate for MeshServiceCoreDelegate {
 
     fn on_peer_disconnected(&self, peer_id: String) {
         if let Some(service) = self.service.upgrade() {
-            service.on_peer_disconnected(peer_id);
+            service.on_peer_disconnected(peer_id.clone());
             if let Some(delegate) = service.external_delegate.lock().as_ref() {
                 delegate.on_peer_disconnected(peer_id);
             }
@@ -1257,10 +1257,25 @@ pub trait PlatformBridge: Send + Sync {
 
 #[derive(Debug, Clone)]
 pub struct DeviceProfile {
+    pub peer_id: Option<String>,
+    pub device_id: Option<String>,
     pub battery_pct: u8,
     pub is_charging: bool,
     pub has_wifi: bool,
     pub motion_state: MotionState,
+}
+
+impl Default for DeviceProfile {
+    fn default() -> Self {
+        Self {
+            peer_id: None,
+            device_id: None,
+            battery_pct: 100,
+            is_charging: false,
+            has_wifi: false,
+            motion_state: MotionState::Stationary,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/core/src/mobile_bridge.rs
+++ b/core/src/mobile_bridge.rs
@@ -934,9 +934,6 @@ impl MeshService {
         // Persist the new DeviceState.
         *self.device_state.write() = Some(new_state.clone());
 
-        // Also keep the legacy DeviceProfile for callers that still use it.
-        *self.current_device_profile.lock() = Some(profile.clone());
-
         // Derive and apply behavior adjustments using the new engine.
         let adj_profile = self.auto_adjust.compute_profile(profile.clone());
         let ble_adj = self.auto_adjust.compute_ble_adjustment(adj_profile);
@@ -970,6 +967,9 @@ impl MeshService {
             bridge.on_network_changed(profile.has_wifi, false); // Cellular not in profile yet
             bridge.on_motion_changed(profile.motion_state);
         }
+
+        // Also keep the legacy DeviceProfile for callers that still use it.
+        *self.current_device_profile.lock() = Some(profile);
     }
 
     /// Compute recommended behavior from a device state snapshot.

--- a/core/src/mobile_bridge.rs
+++ b/core/src/mobile_bridge.rs
@@ -588,6 +588,9 @@ impl MeshService {
                                 Ok(handle) => {
                                     tracing::info!("Swarm started, wiring bridge");
                                     swarm_bridge.set_handle(handle.clone());
+                                    if let Some(core_ref) = iron_core_handle.as_ref() {
+                                        core_ref.set_swarm_handle(handle.clone());
+                                    }
                                     *swarm_mode_state.lock() = Some(headless_mode);
                                     // Apply stored relay budget
                                     let budget = *relay_budget_init.lock();
@@ -611,26 +614,35 @@ impl MeshService {
                                                                 // RELAY: Forward to next hop
                                                                 let next_hop_hex = msg.recipient_id.clone();
                                                                 let payload = msg.payload.clone();
-                                                                
+
                                                                 eprintln!("[IronCore] 🧅 Onion relay: forwarding to {}", next_hop_hex);
                                                                 if let Ok(next_hop_bytes) = hex::decode(&next_hop_hex) {
-                                                                    if let Ok(libp2p_pk) = libp2p::identity::ed25519::PublicKey::try_from_bytes(&next_hop_bytes[..32]) {
-                                                                        let next_peer_id = libp2p::PeerId::from_public_key(&libp2p::identity::PublicKey::from(libp2p_pk));
-                                                                        
-                                                                        let bridge_clone = swarm_bridge.clone();
-                                                                        let stats_clone = stats.clone();
-                                                                        let core_owned = core_ref.clone();
-                                                                        tokio::spawn(async move {
-                                                                            // B1_CORE_ENTRY_006: Apply timing jitter to thwart correlation attacks
-                                                                            let delay_ms = core_owned.relay_jitter_delay("Normal".to_string());
-                                                                            if delay_ms > 0 {
-                                                                                tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-                                                                            }
-                                                                            let _ = bridge_clone.send_message(next_peer_id.to_string(), payload, None, None);
-                                                                        });
-                                                                        
-                                                                        let mut s = stats_clone.lock();
-                                                                        s.messages_relayed += 1;
+                                                                    if let Some(next_hop_key_bytes) = next_hop_bytes
+                                                                        .get(..32)
+                                                                        .and_then(|bytes| <&[u8; 32]>::try_from(bytes).ok())
+                                                                    {
+                                                                        if let Ok(libp2p_pk) = libp2p::identity::ed25519::PublicKey::try_from_bytes(next_hop_key_bytes) {
+                                                                            let next_peer_id = libp2p::PeerId::from_public_key(&libp2p::identity::PublicKey::from(libp2p_pk));
+
+                                                                            let bridge_clone = swarm_bridge.clone();
+                                                                            let stats_clone = stats.clone();
+                                                                            let core_owned = core_ref.clone();
+                                                                            tokio::spawn(async move {
+                                                                                // B1_CORE_ENTRY_006: Apply timing jitter to thwart correlation attacks
+                                                                                let delay_ms = core_owned.relay_jitter_delay("Normal".to_string());
+                                                                                if delay_ms > 0 {
+                                                                                    tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+                                                                                }
+                                                                                let _ = bridge_clone.send_message(next_peer_id.to_string(), payload, None, None);
+                                                                            });
+
+                                                                            let mut s = stats_clone.lock();
+                                                                            s.messages_relayed += 1;
+                                                                        } else {
+                                                                            tracing::warn!("Failed to parse onion relay next hop as ed25519 public key");
+                                                                        }
+                                                                    } else {
+                                                                        tracing::warn!("Onion relay next hop hex decoded to fewer than 32 bytes");
                                                                     }
                                                                 }
                                                             } else {
@@ -923,7 +935,7 @@ impl MeshService {
         *self.device_state.write() = Some(new_state.clone());
 
         // Also keep the legacy DeviceProfile for callers that still use it.
-        *self.current_device_profile.lock() = Some(profile);
+        *self.current_device_profile.lock() = Some(profile.clone());
 
         // Derive and apply behavior adjustments using the new engine.
         let adj_profile = self.auto_adjust.compute_profile(profile.clone());
@@ -1273,7 +1285,7 @@ impl Default for DeviceProfile {
             battery_pct: 100,
             is_charging: false,
             has_wifi: false,
-            motion_state: MotionState::Stationary,
+            motion_state: MotionState::Still,
         }
     }
 }
@@ -2557,6 +2569,7 @@ mod tests {
             is_charging: false,
             has_wifi: true,
             motion_state: MotionState::Still,
+            ..DeviceProfile::default()
         };
         let state = DeviceState::from_profile(&profile);
         assert_eq!(state.battery_level, 55);
@@ -2580,6 +2593,7 @@ mod tests {
             is_charging: false,
             has_wifi: true,
             motion_state: MotionState::Still,
+            ..DeviceProfile::default()
         };
         svc.update_device_state(profile);
 
@@ -2604,6 +2618,7 @@ mod tests {
             is_charging: false,
             has_wifi: true,
             motion_state: MotionState::Walking,
+            ..DeviceProfile::default()
         });
 
         // Transition to low battery
@@ -2612,6 +2627,7 @@ mod tests {
             is_charging: false,
             has_wifi: false,
             motion_state: MotionState::Walking,
+            ..DeviceProfile::default()
         });
 
         let adj = svc.recommended_behavior().unwrap();
@@ -2625,6 +2641,7 @@ mod tests {
             is_charging: false,
             has_wifi: false,
             motion_state: MotionState::Still,
+            ..DeviceProfile::default()
         });
 
         let adj = svc.recommended_behavior().unwrap();

--- a/core/src/routing/negative_cache.rs
+++ b/core/src/routing/negative_cache.rs
@@ -179,7 +179,7 @@ pub struct NegativeCache {
 }
 
 /// Statistics for the negative cache
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct NegativeCacheStats {
     /// Total number of negative checks performed
     pub negative_checks: u64,

--- a/core/src/routing/resume_prefetch.rs
+++ b/core/src/routing/resume_prefetch.rs
@@ -384,7 +384,7 @@ impl ResumePrefetchManager {
 }
 
 /// Statistics for prefetch operations
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct PrefetchStats {
     pub total_routes: usize,
     pub fresh_routes: usize,

--- a/core/src/routing/timeout_budget.rs
+++ b/core/src/routing/timeout_budget.rs
@@ -14,7 +14,7 @@
 use web_time::{Duration, Instant};
 
 /// Discovery phases in order of increasing cost
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum DiscoveryPhase {
     /// Phase 1: Local cache lookup (cheapest, ~1ms)
     LocalCache,
@@ -192,7 +192,7 @@ impl TimeoutBudget {
 }
 
 /// Summary of budget usage for logging/metrics
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct BudgetSummary {
     pub total_budget: Duration,
     pub elapsed: Duration,

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -19,9 +19,9 @@ pub use history::{HistoryManager, HistoryStats, MessageDirection, MessageRecord}
 pub use inbox::{Inbox, ReceivedMessage};
 pub use outbox::{Outbox, QueuedMessage};
 pub use relay_custody::{
-    CustodyEnforcement, CustodyError, CustodyMessage, CustodyState, CustodyTransition,
-    RegistrationState, RegistrationStateInfo, RegistrationTransition, RelayCustodyStore,
-    RelayRegistry,
+    ActiveRelayInfo, CustodyEnforcement, CustodyError, CustodyMessage, CustodyState,
+    CustodyTransition, RegistrationState, RegistrationStateInfo, RegistrationTransition,
+    RelayCustodyStore, RelayRegistry,
 };
 pub use storage::{DiskStats, RetentionConfig, StorageManager};
 pub use sweeper::*;

--- a/core/src/store/relay_custody.rs
+++ b/core/src/store/relay_custody.rs
@@ -104,6 +104,13 @@ pub struct RegistrationStateInfo {
     pub seniority_timestamp: Option<u64>,
 }
 
+/// A relay that has an active registration, as returned by `RelayRegistry::list_active`.
+#[derive(Debug, Clone)]
+pub struct ActiveRelayInfo {
+    /// Identity-id (Blake3 hex of the Ed25519 public key) — used as the routing key.
+    pub public_key_hex: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CustodyError {
     DeviceMismatch,
@@ -1097,6 +1104,27 @@ impl Default for RelayCustodyStore {
 impl RelayRegistry {
     pub fn new(backend: Arc<dyn StorageBackend>) -> Self {
         Self { backend }
+    }
+
+    /// Return all actively-registered relay identities.
+    /// Each entry's `public_key_hex` is the identity_id (Blake3 hex of the public key),
+    /// which serves as the routing identifier for onion-circuit construction.
+    pub fn list_active(&self) -> Vec<ActiveRelayInfo> {
+        self.backend
+            .scan_prefix(REGISTRATION_STATE_PREFIX.as_bytes())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(_, value)| bincode::deserialize::<RegistrationRecord>(&value).ok())
+            .filter_map(|record| {
+                if matches!(record.state, RegistrationState::Active { .. }) {
+                    Some(ActiveRelayInfo {
+                        public_key_hex: record.identity_id,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn register(

--- a/core/src/store/storage.rs
+++ b/core/src/store/storage.rs
@@ -1,3 +1,4 @@
+use crate::store::backend::StorageBackend;
 use crate::store::history::HistoryManager;
 use crate::store::logs::LogManager;
 use crate::IronCoreError;
@@ -82,6 +83,12 @@ impl StorageManager {
         stats.free_bytes = free;
 
         tracing::debug!("Disk stats updated: free {} / total {}", free, total);
+    }
+
+    /// Return the underlying storage backend, delegated from the HistoryManager.
+    /// Used by consumers that need to persist auxiliary data (e.g. audit log).
+    pub fn backend(&self) -> Arc<dyn StorageBackend> {
+        self.history.backend()
     }
 
     /// Perform maintenance to enforce retention policies and ensure free disk space.

--- a/core/src/transport/swarm.rs
+++ b/core/src/transport/swarm.rs
@@ -3073,7 +3073,7 @@ pub async fn start_swarm_with_config(
                                 if should_report {
                                     reported_peer_info.insert(peer_id, (info.agent_version.clone(), info.listen_addrs.clone()));
                                     // Emit event for application layer
-                                    let public_key_hex = info.public_key.clone().try_into_ed25519().map(|pk| hex::encode(pk.to_bytes()));
+                                    let public_key_hex = info.public_key.clone().try_into_ed25519().ok().map(|pk| hex::encode(pk.to_bytes()));
                                     let _ = event_tx.send(SwarmEvent2::PeerIdentified {
                                         peer_id,
                                         public_key: public_key_hex,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,8 +1,19 @@
 # SCMessenger Current State (Verified)
 
 Status: Active
-Last updated: 2026-04-11
-Last verified: **2026-04-11** (WASM WebSocket Bridge Connectivity Fixed)
+Last updated: 2026-04-28
+Last verified: **2026-04-28** (Comment-targeted verification; full core build still blocked by pre-existing compile errors)
+
+---
+
+## 2026-04-28: Baseline compilation review follow-up
+
+**Status:** ✅ COMMENT FIXES VERIFIED
+
+- `DeviceProfile` now keeps optional `peer_id` and `device_id` aligned between Rust defaults, tests, and the UniFFI UDL surface.
+- `IronCore::libp2p_peer_id()` now derives the network identity from the existing identity keypair instead of a missing accessor.
+- `MeshService` stores the live `SwarmHandle` back into `IronCore`, so swarm query APIs can return live transport state while the service is running.
+- Onion relay forwarding now validates decoded next-hop key length before calling libp2p `try_from_bytes`.
 
 ---
 


### PR DESCRIPTION
## Wiring Phase 1: Baseline Compilation Fixes

Fixes pre-existing compilation errors in scmessenger-core to establish a green baseline for systematic wiring of all 310 handoff tasks.

### Changes

**core/Cargo.toml:**
- Add libc for non-android unix targets (relay_custody.rs filesystem ops)
- Enable phase2_apis feature by default (multipath + reputation routing modules)

**core/src/api.udl:**
- Remove unsupported [Self=ByArc] from MeshService constructor (UniFFI 0.31)

**core/src/lib.rs:**
- Add PeelResult struct for onion routing
- Wire missing IronCore fields: abuse_reputation, routing_engine, auto_adjust_engine
- Add identity accessors: identity_id(), device_id(), libp2p_peer_id(), get_swarm_handle()

**core/src/mobile_bridge.rs:**
- Add peer_id/device_id fields + Default impl for DeviceProfile
- Fix ed25519 PublicKey try_from -> try_from_bytes (libp2p 0.53)
- Fix move errors: clone peer_id before delegate callbacks

### Next
Continue wiring B1-B8 batch order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all 14 compile errors in `scmessenger-core` and wires identity/transport plumbing for Phase 2. Updates `libp2p` 0.53 and `uniffi` 0.31, enables `phase2_apis`, and exposes live swarm/identity access.

- **New Features**
  - Added `PeelResult` for onion routing.
  - `IronCore` wiring: live `swarm_handle` storage/access (`get_swarm_handle`/`set_swarm_handle`), identity accessors (`identity_id`, `device_id`, `libp2p_peer_id`), and `random_port`.
  - `DeviceProfile` gains optional `peer_id`/`device_id` with `Default`; UDL exposes these fields.
  - Stats now serializable for telemetry (`serde` on routing types and budgets; `web-time` with `serde`).
  - Relay custody: new `ActiveRelayInfo` and `RelayRegistry::list_active`; `StorageManager::backend()` exposes the underlying store.

- **Bug Fixes**
  - Removed unsupported `[Self=ByArc]` in UDL (required by `uniffi` 0.31).
  - Onion relay: validate 32-byte next-hop keys and use `ed25519::PublicKey::try_from_bytes` (`libp2p` 0.53).
  - Fixed move/threading issues in `MeshService`: clone `peer_id` for delegates, unify BLE peer tracking via `SwarmBridge`, wrap stats in `Arc<Mutex<...>>`.
  - Swarm: avoid panic when deriving public keys (`try_into_ed25519().ok()`); use `libp2p::PeerId` for parsing.
  - Unix builds: added `libc`; adjusted custody store calls and peer-id handling to current APIs.

<sup>Written for commit e0fb51672f2b7d60903b8df4ed95f7c57efdc828. Summary will update on new commits. <a href="https://cubic.dev/pr/Treystu/SCMessenger/pull/94?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

